### PR TITLE
feat: simplifies the abstraction for Events API messages

### DIFF
--- a/src/event_api/event.rs
+++ b/src/event_api/event.rs
@@ -10,115 +10,21 @@ use serde_with::skip_serializing_none;
 /// [Event API](https://api.slack.com/events?filter=Events)
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
 #[serde(tag = "type")]
-pub enum Event {
-    /// Event callback
-    #[serde(rename = "event_callback")]
-    EventCallback(EventCallback),
-}
-
-impl Event {
-    pub fn block_type(&self) -> EventType {
-        match self {
-            Event::EventCallback(event_callback) => match event_callback.event {
-                EventCallbackType::AppHomeOpened { .. } => EventType::AppHomeOpened,
-                EventCallbackType::AppMention { .. } => EventType::AppMention,
-                EventCallbackType::AppRateLimited { .. } => EventType::AppRateLimited,
-                EventCallbackType::AppRequested { .. } => EventType::AppRequested,
-                EventCallbackType::AppUninstalled { .. } => EventType::AppUninstalled,
-                EventCallbackType::ChannelArchive { .. } => EventType::ChannelArchive,
-                EventCallbackType::ChannelCreated { .. } => EventType::ChannelCreated,
-                EventCallbackType::ChannelDeleted { .. } => EventType::ChannelDeleted,
-                EventCallbackType::ChannelHistoryChanged { .. } => EventType::ChannelHistoryChanged,
-                EventCallbackType::ChannelIDChanged { .. } => EventType::ChannelIDChanged,
-                EventCallbackType::ChannelLeft { .. } => EventType::ChannelLeft,
-                EventCallbackType::ChannelRename { .. } => EventType::ChannelRename,
-                EventCallbackType::ChannelShared { .. } => EventType::ChannelShared,
-                EventCallbackType::ChannelUnarchive { .. } => EventType::ChannelUnarchive,
-                EventCallbackType::ChannelUnshared { .. } => EventType::ChannelUnshared,
-                EventCallbackType::EmojiChanged { .. } => EventType::EmojiChanged,
-                EventCallbackType::GridMigrationFinished { .. } => EventType::GridMigrationFinished,
-                EventCallbackType::GridMigrationStarted { .. } => EventType::GridMigrationStarted,
-                EventCallbackType::GroupArchive { .. } => EventType::GroupArchive,
-                EventCallbackType::GroupClose { .. } => EventType::GroupClose,
-                EventCallbackType::GroupDeleted { .. } => EventType::GroupDeleted,
-                EventCallbackType::GroupHistoryChanged { .. } => EventType::GroupHistoryChanged,
-                EventCallbackType::GroupLeft { .. } => EventType::GroupLeft,
-                EventCallbackType::GroupOpen { .. } => EventType::GroupOpen,
-                EventCallbackType::GroupRename { .. } => EventType::GroupRename,
-                EventCallbackType::GroupUnarchive { .. } => EventType::GroupUnarchive,
-                EventCallbackType::ImClose { .. } => EventType::ImClose,
-                EventCallbackType::ImCreated { .. } => EventType::ImCreated,
-                EventCallbackType::ImHistoryChanged { .. } => EventType::ImHistoryChanged,
-                EventCallbackType::ImOpen { .. } => EventType::ImOpen,
-                EventCallbackType::InviteRequested { .. } => EventType::InviteRequested,
-                EventCallbackType::LinkShared => EventType::LinkShared,
-                EventCallbackType::MemberJoinedChannel { .. } => EventType::MemberJoinedChannel,
-                EventCallbackType::MemberLeftChannel { .. } => EventType::MemberLeftChannel,
-                EventCallbackType::Message { .. } => EventType::Message,
-                EventCallbackType::Other => EventType::Other,
-            },
-        }
-    }
-}
-
-/// [Event API Type](https://api.slack.com/events?filter=Events)
-#[derive(Deserialize, Serialize, Debug, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum EventType {
-    AppHomeOpened,
-    AppMention,
-    AppRateLimited,
-    AppRequested,
-    AppUninstalled,
-    ChannelArchive,
-    ChannelCreated,
-    ChannelDeleted,
-    ChannelHistoryChanged,
-    ChannelIDChanged,
-    ChannelLeft,
-    ChannelRename,
-    ChannelShared,
-    ChannelUnarchive,
-    ChannelUnshared,
-    EmojiChanged,
-    GridMigrationFinished,
-    GridMigrationStarted,
-    GroupArchive,
-    GroupClose,
-    GroupDeleted,
-    GroupHistoryChanged,
-    GroupLeft,
-    GroupOpen,
-    GroupRename,
-    GroupUnarchive,
-    ImClose,
-    ImCreated,
-    ImHistoryChanged,
-    ImOpen,
-    InviteRequested,
-    LinkShared,
-    MemberJoinedChannel,
-    MemberLeftChannel,
-    Message,
-    #[serde(other)]
-    Other,
-}
-
-#[skip_serializing_none]
-#[derive(Deserialize, Serialize, Debug, PartialEq)]
-pub struct EventCallback {
+pub struct Event {
     pub token: String,
     pub team_id: String,
     pub api_app_id: String,
-    pub event: EventCallbackType,
+    pub event: EventCallback,
     pub event_id: String,
     pub event_time: i32,
+    #[serde(rename = "type")]
+    pub _type: String,
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
 #[skip_serializing_none]
 #[serde(rename_all = "snake_case", tag = "type")]
-pub enum EventCallbackType {
+pub enum EventCallback {
     /// User clicked into your App Home
     #[serde(rename = "app_home_opened")]
     AppHomeOpened {
@@ -326,23 +232,21 @@ mod test {
   }
 }"##;
         let event = serde_json::from_str::<Event>(json).unwrap();
-        match event {
-            Event::EventCallback(event_callback) => match event_callback.event {
-                EventCallbackType::AppHomeOpened {
-                    user,
-                    channel,
-                    event_ts,
-                    tab,
-                    view,
-                } => {
-                    assert_eq!(user, "U061F7AUR");
-                    assert_eq!(channel, "D0LAN2Q65");
-                    assert_eq!(event_ts, "1515449522000016");
-                    assert_eq!(tab, "home");
-                    assert_eq!(view.id.unwrap(), "VPASKP233");
-                }
-                _ => panic!("Event callback deserialize into incorrect variant"),
-            },
+        match event.event {
+            EventCallback::AppHomeOpened {
+                user,
+                channel,
+                event_ts,
+                tab,
+                view,
+            } => {
+                assert_eq!(user, "U061F7AUR");
+                assert_eq!(channel, "D0LAN2Q65");
+                assert_eq!(event_ts, "1515449522000016");
+                assert_eq!(tab, "home");
+                assert_eq!(view.id.unwrap(), "VPASKP233");
+            }
+            _ => panic!("Event callback deserialize into incorrect variant"),
         }
     }
 
@@ -361,11 +265,9 @@ mod test {
 }"##;
 
         let event = serde_json::from_str::<Event>(json).unwrap();
-        match event {
-            Event::EventCallback(event_callback) => match event_callback.event {
-                EventCallbackType::Other => assert!(true, "true"),
-                _ => panic!("Event callback deserialize into incorrect variant"),
-            },
+        match event.event {
+            EventCallback::Other => assert!(true, "true"),
+            _ => panic!("Event callback deserialize into incorrect variant"),
         }
     }
 }

--- a/src/socket/event.rs
+++ b/src/socket/event.rs
@@ -117,7 +117,8 @@ pub struct AcknowledgeMessage<'s> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{event_api::event::EventCallbackType, payloads::interactive::InteractiveEventType};
+    use crate::event_api::event::*;
+    use crate::payloads::interactive::InteractiveEventType;
 
     #[test]
     fn deserialize_hello_event() {
@@ -200,13 +201,11 @@ mod test {
                 assert_eq!(envelope_id, "dbdd0ef3-1543-4f94-bfb4-133d0e6c1545");
                 assert!(!accepts_response_payload, "false");
 
-                match payload {
-                    Event::EventCallback(event_callback) => match event_callback.event {
-                        EventCallbackType::AppHomeOpened { user, .. } => {
-                            assert_eq!(user, "U061F7AUR");
-                        }
-                        _ => panic!("Event callback deserialize into incorrect variant"),
-                    },
+                match payload.event {
+                    EventCallback::AppHomeOpened { user, .. } => {
+                        assert_eq!(user, "U061F7AUR");
+                    }
+                    _ => panic!("Event callback deserialize into incorrect variant"),
                 }
             }
             _ => panic!("Event deserialize into incorrect variant"),

--- a/src/socket/socket_mode.rs
+++ b/src/socket/socket_mode.rs
@@ -183,7 +183,7 @@ pub async fn connector_for_ca_file(ca_file_path: &str) -> Result<TlsConnector, E
 
 #[cfg(test)]
 mod test {
-    use crate::event_api::event::{Event, EventCallbackType};
+    use crate::event_api::event::*;
     use crate::http_client::{MockSlackWebAPIClient, SlackWebAPIClient};
     use crate::payloads::interactive::InteractiveEventType;
     use crate::socket::event::{
@@ -238,13 +238,11 @@ mod test {
             assert_eq!(e.envelope_id, "dbdd0ef3-1543-4f94-bfb4-133d0e6c1545");
             assert!(!e.accepts_response_payload, "false");
 
-            match e.payload {
-                Event::EventCallback(event_callback) => match event_callback.event {
-                    EventCallbackType::AppHomeOpened { user, .. } => {
-                        assert_eq!(user, "U061F7AUR");
-                    }
-                    _ => panic!("Event callback deserialize into incorrect variant"),
-                },
+            match e.payload.event {
+                EventCallback::AppHomeOpened { user, .. } => {
+                    assert_eq!(user, "U061F7AUR");
+                }
+                _ => panic!("Event callback deserialize into incorrect variant"),
             }
             log::info!("success on_events_api test");
         }


### PR DESCRIPTION
Simplifies the `Event` abstraction by removing the `EventCallbackType` and `EventType` definitions. Through some better utilization in serde we can simplify these type definitions and avoid an unnecessary abstraction that doesn't add much value.

My goal here was to simplify the existing API - as it seemed like there were easier ways to accomplish what the `EventType` and `EventCallbackType` structs were trying to accomplish. As an added bonus this also reduces the amount of boilerplate you need to have to unwrap the contents of the Events API message.

Previously to access the contents of the `Event` one had to have nested `match` statements

```
match event.payload {
    Event::EventCallback(event_callback) => match event_callback.event {
        EventCallbackType::AppHomeOpened { user, .. } => {
        // Do something here with user
        },
    },
}
```

This PR gets rid of this intermediate abstraction and allows you to match directly on the event while preserving the pattern matching in the previous version (matching on the `EventCallback::AppHomeOpened` type)

```
 match e.payload.event {
    EventCallback::AppHomeOpened { user, .. } => {
        // Do something here with user
    }
}
```