### PR TITLE
feat: refactor and test Event types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,12 @@ features = ["client"]
 [dev-dependencies]
 env_logger = "0.9.0"
 mockall = "0.11.0"
+assert-json-diff = "^2.0.2"
 
 [dev-dependencies.async-tls]
 version = "0.11.0"
 default-features = false
 features = ["server"]
+
+[build]
+incremental = true

--- a/examples/events_app_mention.rs
+++ b/examples/events_app_mention.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use async_trait::async_trait;
 use slack::chat::post_message::{post_message, PostMessageRequest};
-use slack::event_api::event::{Event, EventCallbackType};
+use slack::event_api::event::{Event, EventType};
 use slack::http_client::{default_client, SlackWebAPIClient};
 use slack::socket::event::{EventsAPI, HelloEvent};
 use slack::socket::socket_mode::{ack, EventHandler, SocketMode, Stream};
@@ -51,8 +51,8 @@ where
             .expect("socket mode ack error.");
 
         match e.payload {
-            Event::EventCallback(event_callback) => match event_callback.event {
-                EventCallbackType::AppMention {
+            Event{event, ..} => match event {
+                EventType::AppMention {
                     text,
                     channel,
                     ts,

--- a/src/event_api/app.rs
+++ b/src/event_api/app.rs
@@ -6,6 +6,7 @@ use serde_with::skip_serializing_none;
 
 #[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
+/// See more at <https://api.slack.com/events/app_requested>
 pub struct AppRequest {
     pub id: Option<String>,
     pub app: Option<App>,
@@ -45,4 +46,75 @@ pub struct Scope {
     pub description: Option<String>,
     pub is_sensitive: Option<bool>,
     pub token_type: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::event_api::event::EventType;
+    use assert_json_diff::*;
+    use serde_json::Value;
+
+    #[test]
+    fn deserialized_app_requested_event() {
+        let json = r##"
+        {
+          "type": "app_requested",
+          "app_request":{
+              "id": "1234",
+              "app": {
+                "id": "A5678",
+                "name": "Brent's app",
+                "description": "They're good apps, Bront.",
+                "help_url": "brontsapp.com",
+                "privacy_policy_url": "brontsapp.com",
+                "app_homepage_url": "brontsapp.com",
+                "app_directory_url": "https://slack.slack.com/apps/A102ARD7Y",
+                "is_app_directory_approved": true,
+                "is_internal": false,
+                "additional_info": "none"
+              },
+              "previous_resolution": {
+                 "status": "approved",
+                 "scopes": [
+                  {
+                    "name": "app_requested",
+                    "description": "allows this app to listen for app install requests",
+                    "is_sensitive": false,
+                    "token_type": "user"
+                  }]
+              },
+              "user":{
+                "id": "U1234",
+                "name": "Bront",
+                "email": "bront@brent.com"
+              },
+              "team": {
+                "id": "T1234",
+                "name": "Brant App Team",
+                "domain": "brantappteam"
+              },
+              "enterprise": null,
+              "scopes": [
+                {
+                  "name": "app_requested",
+                  "description": "allows this app to listen for app install requests",
+                  "is_sensitive": false,
+                  "token_type": "user"
+                }
+              ],
+              "message": "none"
+          }
+        }
+        "##;
+        let deserialized = serde_json::from_str::<EventType>(&json).unwrap();
+        // Make comparison between our deserialized struct and generic serde_json Value to ensure
+        // that all expected keys exist
+        let expected: Value = serde_json::from_str(&json).unwrap();
+        assert_json_eq!(deserialized, expected);
+
+        match deserialized {
+            EventType::AppRequested{..} => assert!(true),
+            _ => panic!("unrecognized variant"),
+        }
+    }
 }

--- a/src/event_api/app.rs
+++ b/src/event_api/app.rs
@@ -3,14 +3,25 @@ use crate::users::user::User;
 
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
+use serde_json::Value;
 
 #[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
 /// See more at <https://api.slack.com/events/app_requested>
+///
+/// Note that the `enterprise` field is a bit ambiguous. Slack's official
+/// documentation says this value may be null or not null (but does not provide
+/// an example). Therefore we use the `serde_json::Value::Null` variant to
+/// represent this possibility
 pub struct AppRequest {
-    pub id: Option<String>,
     pub app: Option<App>,
+    pub enterprise: Value,
+    pub id: Option<String>,
+    pub message: Option<String>,
     pub previous_resolution: Option<PreviousResolution>,
+    pub scopes: Option<Vec<Scope>>,
+    pub team: Option<Team>,
+    pub user: Option<User>,
 }
 
 #[skip_serializing_none]
@@ -26,10 +37,6 @@ pub struct App {
     pub is_app_directory_approved: Option<bool>,
     pub is_internal: Option<bool>,
     pub additional_info: Option<String>,
-    pub user: Option<User>,
-    pub team: Option<Team>,
-    pub scopes: Option<Vec<Scope>>,
-    pub message: Option<String>,
 }
 
 #[skip_serializing_none]

--- a/src/event_api/event.rs
+++ b/src/event_api/event.rs
@@ -181,6 +181,29 @@ pub enum EventType {
         is_ext_shared: bool,
         event_ts: String,
     },
+    /// Do not Disturb settings changed for the current user
+    ///
+    /// <https://api.slack.com/events/dnd_updated>
+    #[serde(rename = "dnd_updated")]
+    DoNotDisturbUpdated {
+        user: String,
+        dnd_status: DoNotDisturbStatus
+    },
+    /// Do not Disturb settings changed for a member
+    ///
+    /// <https://api.slack.com/events/dnd_updated_user>
+    #[serde(rename = "dnd_updated_user")]
+    DoNotDisturbUpdatedUser {
+        user: String,
+        dnd_status: DoNotDisturbStatus
+    },
+    /// The workspace email domain has changed
+    ///
+    /// <https://api.slack.com/events/email_domain_changed>
+    EmailDomainChanged {
+        email_domain: String,
+        event_ts: String,
+    },
     /// A custom emoji has been added or changed
     #[serde(rename = "emoji_changed")]
     EmojiChanged {
@@ -278,6 +301,15 @@ pub enum EventType {
     MessageSubtype(MessageSubtype),
     #[serde(other)]
     Other,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+pub struct DoNotDisturbStatus {
+    pub dnd_enabled: bool,
+    pub next_dnd_start_ts: u32,
+    pub next_dnd_end_ts: u32,
+    pub snooze_enabled: Option<bool>,
+    pub snooze_endtime: Option<u32>,
 }
 
 #[cfg(test)]
@@ -532,6 +564,64 @@ mod test {
         match event.event {
             EventType::ChannelDeleted{..} => assert!(true),
             _ => panic!("Did not deserialize into expected variant ChannelDeleted"),
+        }
+    }
+
+    #[test]
+    fn deserializes_do_not_disturb_updated() {
+        let json = r##"
+          {
+            "token": "XXYYZZ",
+            "team_id": "TXXXXXXXX",
+            "api_app_id": "AXXXXXXXXX",
+            "event": {
+                "type": "dnd_updated",
+                "user": "U1234",
+                "dnd_status": {
+                    "dnd_enabled": true,
+                    "next_dnd_start_ts": 1450387800,
+                    "next_dnd_end_ts": 1450423800,
+                    "snooze_enabled": true,
+                    "snooze_endtime": 1450373897
+                }
+            },
+            "type": "event_callback",
+            "event_id": "EvXXXXXXXX",
+            "event_time": 1234567890
+          }
+        "##;
+        let event = serde_json::from_str::<Event>(json).unwrap();
+        match event.event {
+            EventType::DoNotDisturbUpdated{..} => assert!(true),
+            _ => panic!("Did not deserialize into expected variant DoNotDisturbUpdated"),
+        }
+    }
+
+    #[test]
+    fn deserializes_do_not_disturb_updated_user() {
+        let json = r##"
+          {
+            "token": "XXYYZZ",
+            "team_id": "TXXXXXXXX",
+            "api_app_id": "AXXXXXXXXX",
+            "event": {
+                "type": "dnd_updated_user",
+                "user": "U1234",
+                "dnd_status": {
+                    "dnd_enabled": true,
+                    "next_dnd_start_ts": 1450387800,
+                    "next_dnd_end_ts": 1450423800
+                }
+            },
+            "type": "event_callback",
+            "event_id": "EvXXXXXXXX",
+            "event_time": 1234567890
+          }
+        "##;
+        let event = serde_json::from_str::<Event>(json).unwrap();
+        match event.event {
+            EventType::DoNotDisturbUpdatedUser{..} => assert!(true),
+            _ => panic!("Did not deserialize into expected variant DoNotDisturbUpdatedUser"),
         }
     }
 

--- a/src/event_api/event.rs
+++ b/src/event_api/event.rs
@@ -3,6 +3,7 @@
 use crate::channels::channel::Channel;
 use crate::event_api::app::AppRequest;
 use crate::event_api::messages::{MessageBasic, MessageSubtype};
+use crate::files::file::{File};
 use crate::team::teams::Team;
 use crate::views::view::View;
 use serde::{Deserialize, Serialize};
@@ -209,6 +210,51 @@ pub enum EventType {
     /// <https://api.slack.com/events/emoji_changed>
     #[serde(rename = "emoji_changed")]
     EmojiChanged(EmojiSubtype),
+    /// A file was changed
+    ///
+    /// <https://api.slack.com/events/file_change>
+    FileChange {
+        file_id: String,
+        file: File,
+    },
+    /// A file was created
+    ///
+    /// <https://api.slack.com/events/file_created>
+    FileCreated {
+        file_id: String,
+        file: File,
+    },
+    /// A file was deleted
+    ///
+    /// <https://api.slack.com/events/file_deleted>
+    FileDeleted {
+        file_id: String,
+        event_ts: String,
+    },
+    /// A file was made public
+    ///
+    /// <https://api.slack.com/events/file_public>
+    FilePublic {
+        file_id: String,
+        file: File,
+    },
+    /// A file was shared
+    ///
+    /// <https://api.slack.com/events/file_shared>
+    FileShared {
+        channel_id: String,
+        event_ts: String,
+        file_id: String,
+        file: File,
+        user_id: String,
+    },
+    /// A file was unshared
+    ///
+    /// <https://api.slack.com/events/file_unshared>
+    FileUnshared {
+        file_id: String,
+        file: File,
+    },
     /// An enterprise grid migration has finished on this workspace.
     GridMigrationFinished,
     /// An enterprise grid migration has started on this workspace.
@@ -701,6 +747,32 @@ mod test {
                 }
             },
             _ => panic!("Did not deserialize into expected variant EmojiChanged"),
+        }
+    }
+
+    #[test]
+    fn deserializes_file_change() {
+        let json = r##"
+          {
+            "token": "XXYYZZ",
+            "team_id": "TXXXXXXXX",
+            "api_app_id": "AXXXXXXXXX",
+            "event": {
+                "type": "file_change",
+                "file_id": "F2147483862",
+                "file": {
+                    "id": "F2147483862"
+                }
+            },
+            "type": "event_callback",
+            "event_id": "EvXXXXXXXX",
+            "event_time": 1234567890
+          }
+        "##;
+        let event = serde_json::from_str::<Event>(json).unwrap();
+        match event.event {
+            EventType::FileChange{..} => assert!(true),
+            _ => panic!("Did not deserialize into expected variant EmojiSubtype::Remove")
         }
     }
 

--- a/src/event_api/event.rs
+++ b/src/event_api/event.rs
@@ -88,7 +88,18 @@ pub enum EventType {
       app_request: AppRequest
     },
     /// Your Slack app was uninstalled.
+    ///
+    /// <https://api.slack.com/events/app_uninstalled>
     AppUninstalled,
+    /// A call was rejected
+    ///
+    /// <https://api.slack.com/events/call_rejected>
+    CallRejected {
+      call_id: String,
+      channel_id: String,
+      external_unique_id: String,
+      user_id: String,
+    },
     /// A channel was archived
     #[serde(rename = "channel_archive")]
     ChannelArchive { channel: String, user: String },
@@ -311,10 +322,20 @@ mod test {
     fn deserializes_accounts_changed() {
         let json = r##"
         {
-          "type": "accounts_changed"
-        }"##;
-        let event = serde_json::from_str::<EventType>(json).unwrap();
-        match event {
+          "token": "12345FVmRUzNDOAu12345h",
+          "team_id": "TL1BBBQBD",
+          "api_app_id": "BBBU04BB4",
+          "event": {
+              "type": "accounts_changed"
+          },
+          "type": "event_callback",
+          "event_id": "EvLLACMB6BB",
+          "event_time": 1563448153,
+          "authed_users": ["UBBB1TYR5"]
+        }
+        "##;
+        let event = serde_json::from_str::<Event>(json).unwrap();
+        match event.event {
             EventType::AccountsChanged{..} => assert!(true),
             _ => panic!("Did not deserialize into expected variant"),
         }
@@ -351,6 +372,56 @@ mod test {
         let event = serde_json::from_str::<EventType>(json).unwrap();
         match event {
             EventType::AppMention{..} => assert!(true),
+            _ => panic!("Did not deserialize into expected variant"),
+        }
+    }
+
+    #[test]
+    fn deserializes_call_rejected() {
+        let json = r##"
+        {
+          "token": "12345FVmRUzNDOAu12345h",
+          "team_id": "TL1BBBQBD",
+          "api_app_id": "BBBU04BB4",
+          "event": {
+            "type": "call_rejected",
+            "call_id": "RL731AVEF",
+            "user_id": "ULJS1TYR5",
+            "channel_id": "DL5JN9K0T",
+            "external_unique_id": "123-456-7890"
+          },
+          "type": "event_callback",
+          "event_id": "EvLLACMB6BB",
+          "event_time": 1563448153,
+          "authed_users": ["UBBB1TYR5"]
+        }
+        "##;
+        let event = serde_json::from_str::<Event>(json).unwrap();
+        println!("{:?}", event.event);
+        match event.event {
+            EventType::CallRejected{..} => assert!(true),
+            _ => panic!("Did not deserialize into expected variant CallRejected"),
+        }
+    }
+
+    #[test]
+    fn deserializes_app_uninstalled() {
+        let json = r##"
+          {
+            "token": "XXYYZZ",
+            "team_id": "TXXXXXXXX",
+            "api_app_id": "AXXXXXXXXX",
+            "event": {
+              "type": "app_uninstalled"
+            },
+            "type": "event_callback",
+            "event_id": "EvXXXXXXXX",
+            "event_time": 1234567890
+          }
+        "##;
+        let event = serde_json::from_str::<Event>(json).unwrap();
+        match event.event {
+            EventType::AppUninstalled{..} => assert!(true),
             _ => panic!("Did not deserialize into expected variant"),
         }
     }

--- a/src/event_api/event.rs
+++ b/src/event_api/event.rs
@@ -3,6 +3,7 @@
 use crate::channels::channel::Channel;
 use crate::event_api::app::AppRequest;
 use crate::event_api::messages::{MessageBasic, MessageSubtype, MessageMetadata};
+use crate::items::item::{Item};
 use crate::files::file::{File};
 use crate::team::teams::Team;
 use crate::views::view::View;
@@ -440,6 +441,45 @@ pub enum EventType {
         previous_metadata: MessageMetadata,
         team_id: String,
         user_id: String,
+    },
+    /// A pin was added to a channel
+    ///
+    /// <https://api.slack.com/events/pin_added>
+    PinAdded {
+        channel_id: String,
+        event_ts: String,
+        item: Item,
+        user: String,
+    },
+    /// A pin was removed from a channel
+    ///
+    /// <https://api.slack.com/events/pin_removed>
+    PinRemoved {
+        channel_id: String,
+        event_ts: String,
+        has_pins: bool,
+        item: Item,
+        user: String,
+    },
+    /// A member added an emoji reaction
+    ///
+    /// <https://api.slack.com/events/reaction_added>
+    ReactionAdded {
+        event_ts: String,
+        item: Item,
+        item_user: String,
+        reaction: String,
+        user: String,
+    },
+    /// A member removed an emoji reaction
+    ///
+    /// <https://api.slack.com/events/reaction_removed>
+    ReactionRemoved {
+        event_ts: String,
+        item: Item,
+        item_user: String,
+        reaction: String,
+        user: String,
     },
     #[serde(other)]
     Other,
@@ -1102,6 +1142,37 @@ mod test {
         let event = serde_json::from_str::<Event>(json).unwrap();
         match event.event {
             EventType::MessageMetadataUpdated{..} => assert!(true),
+            _ => panic!("Did not deserialize into expected variant MessageMetadataUpdated")
+        }
+    }
+
+    #[test]
+    fn deserializes_reaction_added() {
+        let json = r##"
+        {
+            "token": "XXYYZZ",
+            "team_id": "TXXXXXXXX",
+            "api_app_id": "AXXXXXXXXX",
+            "event": {
+                "type": "reaction_added",
+                "user": "U024BE7LH",
+                "reaction": "thumbsup",
+                "item_user": "U0G9QF9C6",
+                "item": {
+                    "type": "message",
+                    "channel": "C0G9QF9GZ",
+                    "ts": "1360782400.498405"
+                },
+                "event_ts": "1360782804.083113"
+            },
+            "type": "event_callback",
+            "event_id": "EvXXXXXXXX",
+            "event_time": 1234567890
+        }
+        "##;
+        let event = serde_json::from_str::<Event>(json).unwrap();
+        match event.event {
+            EventType::ReactionAdded{..} => assert!(true),
             _ => panic!("Did not deserialize into expected variant MessageMetadataUpdated")
         }
     }

--- a/src/event_api/event.rs
+++ b/src/event_api/event.rs
@@ -3,9 +3,11 @@
 use crate::channels::channel::Channel;
 use crate::event_api::app::AppRequest;
 use crate::event_api::messages::{MessageBasic, MessageSubtype, MessageMetadata};
+use crate::invites::invites::{Invite};
 use crate::items::item::{Item};
 use crate::files::file::{File};
-use crate::team::teams::Team;
+use crate::team::teams::{Team};
+use crate::users::user::{User};
 use crate::views::view::View;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -480,6 +482,47 @@ pub enum EventType {
         item_user: String,
         reaction: String,
         user: String,
+    },
+    /// A shared channel invite was accepted
+    ///
+    /// <https://api.slack.com/events/shared_channel_invite_accepted>
+    SharedChannelInviteAccepted {
+        accepting_user: User,
+        approval_required: bool,
+        channel: Channel,
+        event_ts: String,
+        invite: Invite,
+        teams_in_channel: Vec<Team>,
+    },
+    /// A shared channel invite was approved
+    ///
+    /// <https://api.slack.com/events/shared_channel_invite_approved>
+    SharedChannelInviteApproved {
+        approving_user: User,
+        approving_team_id: String,
+        channel: Channel,
+        event_ts: String,
+        invite: Invite,
+        teams_in_channel: Vec<Team>,
+    },
+    /// A shared channel invite was declined
+    ///
+    /// <https://api.slack.com/events/shared_channel_invite_declined>
+    SharedChannelInviteDeclined {
+        channel: Channel,
+        declining: User,
+        declining_team_id: String,
+        event_ts: String,
+        invite: Invite,
+        teams_in_channel: Vec<Team>,
+    },
+    /// A shared channel invite was received
+    ///
+    /// <https://api.slack.com/events/shared_channel_invite_received>
+    SharedChannelInviteReceived {
+        channel: Channel,
+        event_ts: String,
+        invite: Invite,
     },
     #[serde(other)]
     Other,
@@ -1143,6 +1186,164 @@ mod test {
         match event.event {
             EventType::MessageMetadataUpdated{..} => assert!(true),
             _ => panic!("Did not deserialize into expected variant MessageMetadataUpdated")
+        }
+    }
+
+    #[test]
+    fn deserializes_shared_channel_invite_accepted() {
+        let json = r##"
+        {
+            "token": "XXYYZZ",
+            "team_id": "TXXXXXXXX",
+            "api_app_id": "AXXXXXXXXX",
+            "event": {
+                "type": "shared_channel_invite_accepted",
+                "approval_required": false,
+                "invite": {
+                    "id": "I028YDERZSQ",
+                    "date_created": 1626876000,
+                    "date_invalid": 1628085600,
+                    "inviting_team": {
+                        "id": "T12345678",
+                        "name": "Corgis",
+                        "is_verified": false,
+                        "domain": "corgis",
+                        "date_created": 1480946400
+                    },
+                    "inviting_user": {
+                        "id": "U12345678",
+                        "team_id": "T12345678",
+                        "name": "crus",
+                        "updated": 1608081902,
+                        "profile": {
+                            "real_name": "Corgis Rus",
+                            "display_name": "Corgis Rus",
+                            "real_name_normalized": "Corgis Rus",
+                            "display_name_normalized": "Corgis Rus",
+                            "team": "T12345678",
+                            "avatar_hash": "gcfh83a4c72k",
+                            "email": "corgisrus@slack-corp.com",
+                            "image_24": "https://placekitten.com/24/24",
+                            "image_32": "https://placekitten.com/32/32",
+                            "image_48": "https://placekitten.com/48/48",
+                            "image_72": "https://placekitten.com/72/72",
+                            "image_192": "https://placekitten.com/192/192",
+                            "image_512": "https://placekitten.com/512/512"
+                        }
+                    },
+                    "recipient_email": "golden@doodle.com",
+                    "recipient_user_id": "U87654321"
+                },
+                "channel": {
+                    "id": "C12345678",
+                    "is_private": false,
+                    "is_im": false,
+                    "name": "test-slack-connect"
+                },
+                "teams_in_channel": [
+                {
+                    "id": "T12345678",
+                    "name": "Corgis",
+                    "is_verified": false,
+                    "domain": "corgis",
+                    "date_created": 1626789600
+                }
+                ],
+                "accepting_user": {
+                    "id": "U87654321",
+                    "team_id": "T87654321",
+                    "name": "golden",
+                    "updated": 1624406113,
+                    "profile": {
+                        "real_name": "Golden Doodle",
+                        "display_name": "Golden",
+                        "real_name_normalized": "Golden Doodle",
+                        "display_name_normalized": "Golden",
+                        "team": "T87654321",
+                        "avatar_hash": "g717728b118x",
+                        "email": "golden@doodle.com",
+                        "image_24": "https://placekitten.com/24/24",
+                        "image_32": "https://placekitten.com/32/32",
+                        "image_48": "https://placekitten.com/48/48",
+                        "image_72": "https://placekitten.com/72/72",
+                        "image_192": "https://placekitten.com/192/192",
+                        "image_512": "https://placekitten.com/512/512"
+                    }
+                },
+                "event_ts": "1626877800.000000"
+            },
+            "type": "event_callback",
+            "event_id": "EvXXXXXXXX",
+            "event_time": 1234567890
+        }
+        "##;
+        let event = serde_json::from_str::<Event>(json).unwrap();
+        match event.event {
+            EventType::SharedChannelInviteAccepted{..} => assert!(true),
+            _ => panic!("Did not deserialize into expected variant SharedChannelInviteAccepted")
+        }
+    }
+
+    #[test]
+    fn deserializes_shared_channel_invite_received() {
+        let json = r##"
+        {
+            "token": "XXYYZZ",
+            "team_id": "TXXXXXXXX",
+            "api_app_id": "AXXXXXXXXX",
+            "event": {
+                "type": "shared_channel_invite_received",
+                "invite": {
+                    "id": "I028YDERZSQ",
+                    "date_created": 1626876000,
+                    "date_invalid": 1628085600,
+                    "inviting_team": {
+                        "id": "T12345678",
+                        "name": "Corgis",
+                        "is_verified": false,
+                        "domain": "corgis",
+                        "date_created": 1480946400
+                    },
+                    "inviting_user": {
+                        "id": "U12345678",
+                        "team_id": "T12345678",
+                        "name": "crus",
+                        "updated": 1608081902,
+                        "profile": {
+                            "real_name": "Corgis Rus",
+                            "display_name": "Corgis Rus",
+                            "real_name_normalized": "Corgis Rus",
+                            "display_name_normalized": "Corgis Rus",
+                            "team": "T12345678",
+                            "avatar_hash": "gcfh83a4c72k",
+                            "email": "corgisrus@slack-corp.com",
+                            "image_24": "https://placekitten.com/24/24",
+                            "image_32": "https://placekitten.com/32/32",
+                            "image_48": "https://placekitten.com/48/48",
+                            "image_72": "https://placekitten.com/72/72",
+                            "image_192": "https://placekitten.com/192/192",
+                            "image_512": "https://placekitten.com/512/512"
+                        }
+                    },
+                    "recipient_user_id": "U87654321"
+                },
+                "channel": {
+                    "id": "C12345678",
+                    "is_private": false,
+                    "is_im": false,
+                    "name": "test-slack-connect"
+                },
+                "event_ts": "1626876010.000100"
+            },
+            "type": "event_callback",
+            "event_id": "EvXXXXXXXX",
+            "event_time": 1234567890
+        }
+        "##;
+        let event = serde_json::from_str::<Event>(json).unwrap();
+        match event.event {
+            EventType::SharedChannelInviteReceived{..} => assert!(true),
+            _ => panic!("Did not deserialize into expected variant SharedChannelInviteReceived")
         }
     }
 

--- a/src/event_api/event.rs
+++ b/src/event_api/event.rs
@@ -256,37 +256,69 @@ pub enum EventType {
         file: File,
     },
     /// An enterprise grid migration has finished on this workspace.
-    GridMigrationFinished,
+    ///
+    /// <https://api.slack.com/events/grid_migration_finished>
+    GridMigrationFinished {
+        enterprise_id: String,
+    },
     /// An enterprise grid migration has started on this workspace.
-    GridMigrationStarted,
+    ///
+    /// <https://api.slack.com/events/grid_migration_started>
+    GridMigrationStarted {
+        enterprise_id: String,
+    },
     /// A private channel was archived
-    #[serde(rename = "group_archive")]
-    GroupArchive { channel: String },
+    ///
+    /// <https://api.slack.com/events/group_archive>
+    GroupArchive {
+       channel: String
+    },
     /// You closed a private channel
-    #[serde(rename = "group_close")]
-    GroupClose { user: String, channel: String },
+    ///
+    /// <https://api.slack.com/events/group_close>
+    GroupClose {
+        user: String,
+        channel: String
+    },
     /// A private channel was deleted
-    #[serde(rename = "group_deleted")]
-    GroupDeleted { channel: String },
+    ///
+    /// <https://api.slack.com/events/group_deleted>
+    GroupDeleted {
+       channel: String
+    },
     /// A private channel was deleted
-    #[serde(rename = "group_history_changed")]
+    ///
+    /// <https://api.slack.com/events/group_history_changed>
     GroupHistoryChanged {
         latest: String,
         ts: String,
         event_ts: String,
     },
     /// You left a private channel
-    #[serde(rename = "group_left")]
-    GroupLeft { channel: String },
+    ///
+    /// <https://api.slack.com/events/group_left>
+    GroupLeft {
+        channel: String
+    },
     /// You created a group DM
-    #[serde(rename = "group_open")]
-    GroupOpen { user: String, channel: String },
+    ///
+    /// <https://api.slack.com/events/group_open>
+    GroupOpen {
+        user: String,
+        channel: String
+    },
     /// A private channel was renamed
-    #[serde(rename = "group_rename")]
-    GroupRename { channel: Channel },
+    ///
+    /// <https://api.slack.com/events/group_rename>
+    GroupRename {
+        channel: Channel
+    },
     /// A private channel was unarchived
-    #[serde(rename = "group_unarchive")]
-    GroupUnarchive { channel: String },
+    ///
+    /// <https://api.slack.com/events/group_unarchive>
+    GroupUnarchive {
+        channel: String
+    },
     /// You closed a DM
     #[serde(rename = "im_close")]
     ImClose { user: String, channel: String },

--- a/src/event_api/event.rs
+++ b/src/event_api/event.rs
@@ -377,20 +377,22 @@ pub enum EventType {
         links: Vec<Link>,
     },
     /// A user joined a public or private channel
-    #[serde(rename = "member_joined_channel")]
+    ///
+    /// <https://api.slack.com/events/member_joined_channel>
     MemberJoinedChannel {
         user: String,
         channel: String,
-        channel_type: String,
+        channel_type: ChannelType,
         team: String,
         inviter: String,
     },
     /// A user left a public or private channel
-    #[serde(rename = "member_left_channel")]
+    ///
+    /// <https://api.slack.com/events/member_left_channel>
     MemberLeftChannel {
         user: String,
         channel: String,
-        channel_type: String,
+        channel_type: ChannelType,
         team: String,
     },
     /// A message was sent to a channel
@@ -443,6 +445,15 @@ pub struct Link {
 pub enum LinkSource {
     Composer,
     ConversationsHistory,
+}
+
+/// See <https://api.slack.com/events/member_joined_channel> for more
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+pub enum ChannelType {
+    #[serde(rename = "C")]
+    Public,
+    #[serde(rename = "G")]
+    Private
 }
 
 #[cfg(test)]
@@ -889,6 +900,33 @@ mod test {
         match event.event {
             EventType::LinkShared{..} => assert!(true),
             _ => panic!("Did not deserialize into expected variant EventType::LinkShared")
+        }
+    }
+
+    #[test]
+    fn deserializes_member_joined_channel() {
+        let json = r##"
+          {
+            "token": "XXYYZZ",
+            "team_id": "TXXXXXXXX",
+            "api_app_id": "AXXXXXXXXX",
+            "event": {
+                "type": "member_joined_channel",
+                "user": "W06GH7XHN",
+                "channel": "C0698JE0H",
+                "channel_type": "C",
+                "team": "T024BE7LD",
+                "inviter": "U123456789"
+            },
+            "type": "event_callback",
+            "event_id": "EvXXXXXXXX",
+            "event_time": 1234567890
+          }
+        "##;
+        let event = serde_json::from_str::<Event>(json).unwrap();
+        match event.event {
+            EventType::MemberJoinedChannel{..} => assert!(true),
+            _ => panic!("Did not deserialize into expected variant MemberJoinedChannel")
         }
     }
 

--- a/src/event_api/event.rs
+++ b/src/event_api/event.rs
@@ -400,7 +400,20 @@ pub enum EventType {
     Message(MessageBasic),
     #[serde(rename = "message")]
     MessageSubtype(MessageSubtype),
-
+    /// Message metadata was deleted
+    ///
+    /// <https://api.slack.com/events/message_metadata_deleted>
+    MessageMetadataDeleted {
+        app_id: String,
+        bot_id: String,
+        channel_id: String,
+        deleted_ts: String,
+        event_ts: String,
+        message_ts: String,
+        previous_metadata: MessageMetadata,
+        team_id: String,
+        user_id: String,
+    },
     /// Message metadata was posted
     ///
     /// <https://api.slack.com/events/message_metadata_posted>
@@ -411,6 +424,20 @@ pub enum EventType {
         event_ts: String,
         message_ts: String,
         metadata: MessageMetadata,
+        team_id: String,
+        user_id: String,
+    },
+    /// Message metadata was updated
+    ///
+    /// <https://api.slack.com/events/message_metadata_updated>
+    MessageMetadataUpdated {
+        app_id: String,
+        bot_id: String,
+        channel_id: String,
+        event_ts: String,
+        message_ts: String,
+        metadata: MessageMetadata,
+        previous_metadata: MessageMetadata,
         team_id: String,
         user_id: String,
     },
@@ -945,6 +972,47 @@ mod test {
     }
 
     #[test]
+    fn deserializes_message_metadata_deleted() {
+        let json = r##"
+        {
+            "token": "XXYYZZ",
+            "team_id": "TXXXXXXXX",
+            "api_app_id": "AXXXXXXXXX",
+            "event": {
+                "type": "message_metadata_deleted",
+                "channel_id": "CJN879K8A",
+                "event_ts": "1658907498.002500",
+                "previous_metadata":
+                {
+                    "event_type": "task_created",
+                    "event_payload":
+                    {
+                        "id": "TK-2135",
+                        "summary": "New issue with the display of mobile element",
+                        "description": "An end user has found a problem with the new mobile container for data entry. It was reproduced in the current version of IOS.",
+                        "priority": "HIGH",
+                        "resource_type": "TASK"
+                    }
+                },
+                "app_id": "AQF4F123M",
+                "bot_id": "B8241P2B34D",
+                "user_id": "UA8829BFL",
+                "team_id": "T12F3JCAP",
+                "message_ts": "1658905974.587109",
+                "deleted_ts": "1658907498.002500"
+            },
+            "type": "event_callback",
+            "event_id": "EvXXXXXXXX",
+            "event_time": 1234567890
+        }
+        "##;
+        let event = serde_json::from_str::<Event>(json).unwrap();
+        match event.event {
+            EventType::MessageMetadataDeleted{..} => assert!(true),
+            _ => panic!("Did not deserialize into expected variant MessageMetadataDeleted")
+        }
+    }
+    #[test]
     fn deserializes_message_metadata_posted() {
         let json = r##"
         {
@@ -982,6 +1050,59 @@ mod test {
         match event.event {
             EventType::MessageMetadataPosted{..} => assert!(true),
             _ => panic!("Did not deserialize into expected variant MessageMetadataPosted")
+        }
+    }
+
+    #[test]
+    fn deserializes_message_metadata_updated() {
+        let json = r##"
+        {
+            "token": "XXYYZZ",
+            "team_id": "TXXXXXXXX",
+            "api_app_id": "AXXXXXXXXX",
+            "event": {
+                "type": "message_metadata_updated",
+                "channel_id": "CJN879K8A",
+                "event_ts": "1658906295.002200",
+                "previous_metadata":
+                {
+                    "event_type": "task_created",
+                    "event_payload":
+                    {
+                        "id": "TK-2132",
+                        "summary": "New issue with the display of mobile element",
+                        "description": "An end user has found a problem with the new mobile container for data entry. It was reproduced in the current version of IOS.",
+                        "priority": "HIGH",
+                        "resource_type": "TASK"
+                    }
+                },
+                "app_id": "AQF4F123M",
+                "bot_id": "B8241P2B34D",
+                "user_id": "UA8829BFL",
+                "team_id": "T12F3JCAP",
+                "message_ts": "1658905974.587109",
+                "metadata":
+                {
+                    "event_type": "task_created",
+                    "event_payload":
+                    {
+                        "id": "TK-2135",
+                        "summary": "New issue with the display of mobile element",
+                        "description": "An end user has found a problem with the new mobile container for data entry. It was reproduced in the current version of IOS.",
+                        "priority": "HIGH",
+                        "resource_type": "TASK"
+                    }
+                }
+            },
+            "type": "event_callback",
+            "event_id": "EvXXXXXXXX",
+            "event_time": 1234567890
+        }
+        "##;
+        let event = serde_json::from_str::<Event>(json).unwrap();
+        match event.event {
+            EventType::MessageMetadataUpdated{..} => assert!(true),
+            _ => panic!("Did not deserialize into expected variant MessageMetadataUpdated")
         }
     }
 

--- a/src/event_api/event.rs
+++ b/src/event_api/event.rs
@@ -580,6 +580,39 @@ pub enum EventType {
     SubteamUpdated {
         subteam: Subteam,
     },
+    /// Access to a set of teams was granted to your org app
+    ///
+    /// <https://api.slack.com/events/team_access_granted>
+    TeamAccessGranted {
+        team_ids: Vec<String>
+    },
+    /// Access to a set of teams was revoked from your org app
+    ///
+    /// <https://api.slack.com/events/team_access_revoked>
+    TeamAccessRevoked {
+        team_ids: Vec<String>
+    },
+    /// The workspace domain has changed
+    ///
+    /// <https://api.slack.com/events/team_domain_change>
+    TeamAccessRevoked {
+        domain: String,
+        team_id: String,
+        url: String,
+    },
+    /// A new member has joined
+    ///
+    /// <https://api.slack.com/events/team_join>
+    TeamAccessRevoked {
+        user: User,
+    },
+    /// The workspace name has changed
+    ///
+    /// <https://api.slack.com/events/team_rename>
+    TeamRename {
+        name: String,
+        team_id: String,
+    },
     #[serde(other)]
     Other,
 }

--- a/src/event_api/event.rs
+++ b/src/event_api/event.rs
@@ -101,15 +101,30 @@ pub enum EventType {
       user_id: String,
     },
     /// A channel was archived
+    ///
+    /// <https://api.slack.com/events/channel_archive>
     #[serde(rename = "channel_archive")]
-    ChannelArchive { channel: String, user: String },
+    ChannelArchive {
+      channel: String,
+      user: String
+    },
     /// A channel was created
+    ///
+    /// <https://api.slack.com/events/channel_created>
     #[serde(rename = "channel_created")]
-    ChannelCreated { channel: Channel },
+    ChannelCreated {
+      channel: Channel
+    },
     /// A channel was deleted
+    ///
+    /// <https://api.slack.com/events/channel_deleted>
     #[serde(rename = "channel_deleted")]
-    ChannelDeleted { channel: String },
+    ChannelDeleted {
+        channel: String
+    },
     /// Bulk updates were made to a channel's history
+    ///
+    /// <https://api.slack.com/events/channel_history_changed>
     #[serde(rename = "channel_history_changed")]
     ChannelHistoryChanged {
         latest: String,
@@ -117,6 +132,8 @@ pub enum EventType {
         event_ts: String,
     },
     /// A channel ID changed
+    ///
+    /// <https://api.slack.com/events/channel_id_changed>
     #[serde(rename = "channel_id_changed")]
     ChannelIDChanged {
         old_channel_id: String,
@@ -124,12 +141,22 @@ pub enum EventType {
         event_ts: String,
     },
     /// You left a channel
+    ///
+    /// <https://api.slack.com/events/channel_left>
     #[serde(rename = "channel_left")]
-    ChannelLeft { channel: String },
+    ChannelLeft {
+        channel: String
+    },
     /// A channel was renamed
+    ///
+    /// <https://api.slack.com/events/channel_rename>
     #[serde(rename = "channel_rename")]
-    ChannelRename { channel: Channel },
+    ChannelRename {
+        channel: Channel
+    },
     /// A channel has been shared with an external workspace
+    ///
+    /// <https://api.slack.com/events/channel_shared>
     #[serde(rename = "channel_shared")]
     ChannelShared {
         connected_team_id: String,
@@ -137,9 +164,16 @@ pub enum EventType {
         event_ts: String,
     },
     /// A channel was unarchived
+    ///
+    /// <https://api.slack.com/events/channel_unarchive>
     #[serde(rename = "channel_unarchive")]
-    ChannelUnarchive { channel: String, user: String },
+    ChannelUnarchive {
+        channel: String,
+        user: String
+    },
     ///A channel has been unshared with an external workspace
+    ///
+    /// <https://api.slack.com/events/channel_unshared>
     #[serde(rename = "channel_unshared")]
     ChannelUnshared {
         previously_connected_team_id: String,
@@ -423,6 +457,81 @@ mod test {
         match event.event {
             EventType::AppUninstalled{..} => assert!(true),
             _ => panic!("Did not deserialize into expected variant"),
+        }
+    }
+
+    #[test]
+    fn deserializes_channel_archive() {
+        let json = r##"
+          {
+            "token": "XXYYZZ",
+            "team_id": "TXXXXXXXX",
+            "api_app_id": "AXXXXXXXXX",
+            "event": {
+              "type": "channel_archive",
+              "channel": "C024BE91L",
+              "user": "U024BE7LH"
+            },
+            "type": "event_callback",
+            "event_id": "EvXXXXXXXX",
+            "event_time": 1234567890
+          }
+        "##;
+        let event = serde_json::from_str::<Event>(json).unwrap();
+        match event.event {
+            EventType::ChannelArchive{..} => assert!(true),
+            _ => panic!("Did not deserialize into expected variant"),
+        }
+    }
+
+    #[test]
+    fn deserializes_channel_created() {
+        let json = r##"
+          {
+            "token": "XXYYZZ",
+            "team_id": "TXXXXXXXX",
+            "api_app_id": "AXXXXXXXXX",
+            "event": {
+              "type": "channel_created",
+              "channel": {
+                "id": "C024BE91L",
+                "name": "fun",
+                "created": 1360782804,
+                "creator": "U024BE7LH"
+              }
+            },
+            "type": "event_callback",
+            "event_id": "EvXXXXXXXX",
+            "event_time": 1234567890
+          }
+        "##;
+        let event = serde_json::from_str::<Event>(json).unwrap();
+        match event.event {
+            EventType::ChannelCreated{..} => assert!(true),
+            _ => panic!("Did not deserialize into expected variant"),
+        }
+    }
+
+    #[test]
+    fn deserializes_channel_deleted() {
+        let json = r##"
+          {
+            "token": "XXYYZZ",
+            "team_id": "TXXXXXXXX",
+            "api_app_id": "AXXXXXXXXX",
+            "event": {
+              "type": "channel_deleted",
+              "channel": "C024BE91L"
+            },
+            "type": "event_callback",
+            "event_id": "EvXXXXXXXX",
+            "event_time": 1234567890
+          }
+        "##;
+        let event = serde_json::from_str::<Event>(json).unwrap();
+        match event.event {
+            EventType::ChannelDeleted{..} => assert!(true),
+            _ => panic!("Did not deserialize into expected variant ChannelDeleted"),
         }
     }
 

--- a/src/event_api/messages.rs
+++ b/src/event_api/messages.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
+use serde_json::Value;
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
 #[serde(tag = "subtype")]
@@ -64,6 +65,20 @@ pub struct MessageUpdate {
     pub text: String,
     pub ts: String,
     pub user: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+/// Metadata Events are structured data payloads that contain information about
+/// events occurring in your Slack-connected application, in the form of a
+/// custom `event_payload` as part of a message's `metadata` property.
+///
+/// See <https://api.slack.com/reference/metadata> for more
+///
+/// Note here that we use the `serde_json::Value` since the `event_payload` can
+/// be dynamic (user-defined keys and values) which cannot be represented here
+pub struct MessageMetadata {
+    pub event_type: String,
+    pub event_payload: Value,
 }
 
 #[cfg(test)]

--- a/src/event_api/messages.rs
+++ b/src/event_api/messages.rs
@@ -1,0 +1,115 @@
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[serde(tag = "subtype")]
+pub enum MessageSubtype {
+    #[serde(rename = "message_updated")]
+    MessageUpdate,
+    #[serde(rename = "message_replied")]
+    MessageReplied {
+        #[serde(rename = "type", default = "MessageSubtype::default_type")]
+        _type: String,
+        channel: String,
+        event_ts: String,
+        hidden: bool,
+        message: MessageReply,
+        ts: String,
+    }
+}
+
+impl MessageSubtype {
+    fn default_type() -> String {
+        "message".to_string()
+    }
+
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[skip_serializing_none]
+pub struct MessageBasic {
+    pub channel: String,
+    pub channel_type: String,
+    pub edited: Option<MessageEdit>,
+    pub event_ts: String,
+    pub text: String,
+    pub thread_ts: Option<String>,
+    pub ts: String,
+    pub user: String,
+}
+
+// TODO - this could probably be merged with MessageBasic
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+pub struct MessageReply {
+    pub replies: Option<Vec<MessageEdit>>,
+    pub reply_count: u8,
+    pub text: String,
+    pub thread_ts: String,
+    pub ts: String,
+    pub user: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[skip_serializing_none]
+pub struct MessageEdit {
+    pub user: String,
+    pub ts: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[skip_serializing_none]
+pub struct MessageUpdate {
+    pub edited: MessageEdit,
+    pub subtype: String,
+    pub text: String,
+    pub ts: String,
+    pub user: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::event_api::messages::*;
+    use serde_json::Value;
+
+    #[test]
+    fn serializes_message_replied_correctly() {
+        let expected = r##"
+        {
+        "type": "message",
+        "message": {
+          "type": "message",
+          "user": "U1111111",
+          "text": "Was there was there was there what was there was there what was there was there there was there.",
+          "thread_ts": "1482960137.003543",
+          "reply_count": 1,
+          "replies": [
+            {
+              "user": "U2222222",
+              "ts": "1483037603.017503"
+            }
+          ],
+          "ts": "1482960137.003543"
+        },
+        "subtype": "message_replied",
+        "hidden": true,
+        "channel": "C12345678",
+        "event_ts": "1483037604.017506",
+        "ts": "1483037604.017506"
+        }"##;
+
+        let deserialized = serde_json::from_str::<MessageSubtype>(&expected).unwrap();
+        // Reserialize this for later assertions
+        let serialized = serde_json::to_string(&deserialized).unwrap();
+        match deserialized {
+            MessageSubtype::MessageReplied{message, _type, ..} => {
+                assert_eq!(message.user, "U1111111");
+                assert_eq!(_type, "message".to_string());
+            },
+            _ => panic!("Event callback deserialize into incorrect variant"),
+        }
+        // Validate that reserialized JSON contains expected fields
+        let json: Value = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(json["subtype"], "message_replied".to_string());
+        assert_eq!(json["type"], "message".to_string());
+    }
+}

--- a/src/event_api/mod.rs
+++ b/src/event_api/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod app;
 pub mod event;
+pub mod messages;

--- a/src/invites/invites.rs
+++ b/src/invites/invites.rs
@@ -1,0 +1,15 @@
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+use crate::team::teams::{Team};
+use crate::users::user::{User};
+
+#[derive(Deserialize, Serialize, Debug, Default, PartialEq)]
+pub struct Invite {
+    pub id: String,
+    pub date_created: u32,
+    pub date_invalid: u32,
+    pub inviting_team: Team,
+    pub inviting_user: User,
+    pub recipient_email: Option<String>,
+    pub recipient_user_id: String,
+}

--- a/src/invites/mod.rs
+++ b/src/invites/mod.rs
@@ -1,0 +1,1 @@
+pub mod invites;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,7 @@ pub mod error;
 pub mod event_api;
 pub mod files;
 pub mod http_client;
+pub mod invites;
 pub mod items;
 pub mod payloads;
 pub mod profiles;

--- a/src/socket/event.rs
+++ b/src/socket/event.rs
@@ -117,7 +117,7 @@ pub struct AcknowledgeMessage<'s> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{event_api::event::EventCallbackType, payloads::interactive::InteractiveEventType};
+    use crate::payloads::interactive::InteractiveEventType;
 
     #[test]
     fn deserialize_hello_event() {
@@ -200,13 +200,9 @@ mod test {
                 assert_eq!(envelope_id, "dbdd0ef3-1543-4f94-bfb4-133d0e6c1545");
                 assert!(!accepts_response_payload, "false");
 
-                match payload {
-                    Event::EventCallback(event_callback) => match event_callback.event {
-                        EventCallbackType::AppHomeOpened { user, .. } => {
-                            assert_eq!(user, "U061F7AUR");
-                        }
-                        _ => panic!("Event callback deserialize into incorrect variant"),
-                    },
+                match payload.event {
+                    crate::event_api::event::EventType::AppHomeOpened{user, ..} => assert_eq!(user, "U061F7AUR"),
+                    _ => panic!("Event callback deserialize into incorrect variant"),
                 }
             }
             _ => panic!("Event deserialize into incorrect variant"),

--- a/src/socket/socket_mode.rs
+++ b/src/socket/socket_mode.rs
@@ -183,7 +183,7 @@ pub async fn connector_for_ca_file(ca_file_path: &str) -> Result<TlsConnector, E
 
 #[cfg(test)]
 mod test {
-    use crate::event_api::event::{Event, EventCallbackType};
+    use crate::event_api::event::*;
     use crate::http_client::{MockSlackWebAPIClient, SlackWebAPIClient};
     use crate::payloads::interactive::InteractiveEventType;
     use crate::socket::event::{
@@ -239,10 +239,8 @@ mod test {
             assert!(!e.accepts_response_payload, "false");
 
             match e.payload {
-                Event::EventCallback(event_callback) => match event_callback.event {
-                    EventCallbackType::AppHomeOpened { user, .. } => {
-                        assert_eq!(user, "U061F7AUR");
-                    }
+                Event{event, ..} => match event {
+                    EventType::AppHomeOpened {user, .. } => assert_eq!(user, "U061F7AUR"),
                     _ => panic!("Event callback deserialize into incorrect variant"),
                 },
             }

--- a/src/team/info.rs
+++ b/src/team/info.rs
@@ -67,6 +67,7 @@ mod test {
             team: Some(Team {
                 id: Some("T12345".to_string()),
                 name: Some("My Team".to_string()),
+                date_created: None,
                 domain: Some("example".to_string()),
                 email_domain: Some("example.com".to_string()),
                 icon: Some(Icon {
@@ -78,6 +79,7 @@ mod test {
                     image_132: Some("https://...".to_string()),
                     image_default: Some(true),
                 }),
+                is_verified: None,
                 enterprise_id: Some("E1234A12AB".to_string()),
                 enterprise_name: Some("Umbrella Corporation".to_string()),
             }),
@@ -150,6 +152,7 @@ mod test {
             team: Some(Team {
                 id: Some("T12345".to_string()),
                 name: Some("My Team".to_string()),
+                date_created: None,
                 domain: Some("example".to_string()),
                 email_domain: Some("example.com".to_string()),
                 icon: Some(Icon {
@@ -161,6 +164,7 @@ mod test {
                     image_132: Some("https://...".to_string()),
                     image_default: Some(true),
                 }),
+                is_verified: None,
                 enterprise_id: Some("E1234A12AB".to_string()),
                 enterprise_name: Some("Umbrella Corporation".to_string()),
             }),

--- a/src/team/mod.rs
+++ b/src/team/mod.rs
@@ -7,4 +7,5 @@ pub mod integration_logs;
 pub mod log;
 pub mod preferences_list;
 pub mod profile_get;
+pub mod subteams;
 pub mod teams;

--- a/src/team/subteams.rs
+++ b/src/team/subteams.rs
@@ -1,0 +1,41 @@
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::{Value};
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+pub struct Subteam {
+    pub id: String,
+    pub team_id: String,
+    pub is_usergroup: bool,
+    pub name: String,
+    pub description: String,
+    pub handle: String,
+    pub is_external: bool,
+    pub date_create: u32,
+    pub date_update: u32,
+    pub date_delete: u32,
+    pub auto_type: Value,
+    pub created_by: Value,
+    pub updated_by: Value,
+    pub deleted_by: Value,
+    pub prefs: SubteamPrefs,
+    /// Note that the Slack API examples have this as an integer value encoded
+    /// as a string
+    #[serde(deserialize_with = "Subteam::make_int")]
+    pub user_count: u32,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+pub struct SubteamPrefs {
+    pub channels: Vec<String>,
+    pub groups: Vec<String>,
+}
+
+impl Subteam {
+    fn make_int<'de, D>(deserializer: D) -> Result<u32, D::Error>
+        where D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+

--- a/src/team/subteams.rs
+++ b/src/team/subteams.rs
@@ -3,25 +3,30 @@ use serde_json::{Value};
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
 pub struct Subteam {
-    pub id: String,
-    pub team_id: String,
-    pub is_usergroup: bool,
-    pub name: String,
-    pub description: String,
-    pub handle: String,
-    pub is_external: bool,
-    pub date_create: u32,
-    pub date_update: u32,
-    pub date_delete: u32,
     pub auto_type: Value,
+    pub auto_provision: Option<bool>,
+    pub channel_count: Option<u32>,
     pub created_by: Value,
-    pub updated_by: Value,
+    pub date_create: u32,
+    pub date_delete: u32,
+    pub date_update: u32,
     pub deleted_by: Value,
+    pub description: String,
+    pub enterprise_subteam_id: Option<Value>,
+    pub handle: String,
+    pub id: String,
+    pub is_external: bool,
+    pub is_usergroup: bool,
+    pub is_subteam: Option<bool>,
+    pub name: String,
     pub prefs: SubteamPrefs,
+    pub team_id: String,
+    pub updated_by: Value,
+    pub users: Option<Vec<String>>,
     /// Note that the Slack API examples have this as an integer value encoded
     /// as a string
     #[serde(deserialize_with = "Subteam::make_int")]
-    pub user_count: u32,
+    pub user_count: u64,
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
@@ -31,11 +36,16 @@ pub struct SubteamPrefs {
 }
 
 impl Subteam {
-    fn make_int<'de, D>(deserializer: D) -> Result<u32, D::Error>
+    /// Implement a custom deserializer to handle both string quoted integer values and unquoted
+    /// integer values
+    pub fn make_int<'de, D>(deserializer: D) -> Result<u64, D::Error>
         where D: Deserializer<'de>,
     {
-        let s = String::deserialize(deserializer)?;
-        s.parse().map_err(serde::de::Error::custom)
+        match serde::Deserialize::deserialize(deserializer)? {
+            Value::String(s) => s.parse().map_err(serde::de::Error::custom),
+            Value::Number(num) => num.as_u64().ok_or_else(|| serde::de::Error::custom(format!("Could not deserialize {} as number", num))),
+            _ => return Err(serde::de::Error::custom("invalid type")),
+        }
     }
 }
 

--- a/src/team/teams.rs
+++ b/src/team/teams.rs
@@ -6,9 +6,11 @@ use serde_with::skip_serializing_none;
 pub struct Team {
     pub id: Option<String>,
     pub name: Option<String>,
+    pub date_created: Option<u32>,
     pub domain: Option<String>,
     pub email_domain: Option<String>,
     pub icon: Option<Icon>,
+    pub is_verified: Option<bool>,
     pub enterprise_id: Option<String>,
     pub enterprise_name: Option<String>,
 }

--- a/src/users/user.rs
+++ b/src/users/user.rs
@@ -38,6 +38,7 @@ pub struct User {
     pub team_id: Option<String>,
     pub name: Option<String>,
     pub deleted: Option<bool>,
+    pub email: Option<String>,
     pub color: Option<String>,
     pub real_name: Option<String>,
     pub tz: Option<String>,

--- a/src/users/user.rs
+++ b/src/users/user.rs
@@ -4,6 +4,7 @@ use serde_with::skip_serializing_none;
 #[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Default, PartialEq)]
 pub struct UserProfile {
+    pub avatar_hash: Option<String>,
     pub first_name: Option<String>,
     pub last_name: Option<String>,
     pub real_name: Option<String>,
@@ -19,7 +20,7 @@ pub struct UserProfile {
     pub image_72: Option<String>,
     pub image_192: Option<String>,
     pub image_512: Option<String>,
-    pub mage_original: Option<String>,
+    pub image_original: Option<String>,
     pub title: Option<String>,
     pub bot_id: Option<String>,
     pub api_app_id: Option<String>,


### PR DESCRIPTION
**Note this is currently a WIP**

The goal of this PR is the following
1. Simplify the Event types (currently `Event`, `EventTypeCallback`) into a simpler structure. Currently there is a fair amount of abstraction that isn't really necessary
2. Introduce additional unit tests to validate serialization / deserialization. The goal is ensure that inbound JSON payloads deserialize correctly as compared to the JSON in the Slack API documentation.

For point two above, I've introduced the `assert-json-diff` crate which allows you to more easily find the differences between serde_json `Value` objects. The goal is to use this to ensure that we have all the expected keys in the JSON objects.